### PR TITLE
Add Milestone 13-15 Photo Collection

### DIFF
--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection.xcodeproj/project.pbxproj
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection.xcodeproj/project.pbxproj
@@ -1,0 +1,365 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1E0839122D5E0DAC00E2FA3E /* Milestone13_15_PhotoCollectionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0839112D5E0DAC00E2FA3E /* Milestone13_15_PhotoCollectionApp.swift */; };
+		1E0839142D5E0DAC00E2FA3E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0839132D5E0DAC00E2FA3E /* ContentView.swift */; };
+		1E0839162D5E0DB300E2FA3E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1E0839152D5E0DB300E2FA3E /* Assets.xcassets */; };
+		1E0839192D5E0DB300E2FA3E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1E0839182D5E0DB300E2FA3E /* Preview Assets.xcassets */; };
+		1E0839202D5E419A00E2FA3E /* AddImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E08391F2D5E419A00E2FA3E /* AddImageView.swift */; };
+		1E0839242D5E4F2400E2FA3E /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0839232D5E4F2400E2FA3E /* Item.swift */; };
+		1E0839262D5E7D6900E2FA3E /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0839252D5E7D6900E2FA3E /* DetailView.swift */; };
+		1E0839282D5E81EE00E2FA3E /* ContentView-ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0839272D5E81EE00E2FA3E /* ContentView-ViewModel.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1E08390E2D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Milestone13-15_PhotoCollection.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E0839112D5E0DAC00E2FA3E /* Milestone13_15_PhotoCollectionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone13_15_PhotoCollectionApp.swift; sourceTree = "<group>"; };
+		1E0839132D5E0DAC00E2FA3E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		1E0839152D5E0DB300E2FA3E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1E0839182D5E0DB300E2FA3E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		1E08391F2D5E419A00E2FA3E /* AddImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddImageView.swift; sourceTree = "<group>"; };
+		1E0839232D5E4F2400E2FA3E /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		1E0839252D5E7D6900E2FA3E /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		1E0839272D5E81EE00E2FA3E /* ContentView-ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView-ViewModel.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1E08390B2D5E0DAC00E2FA3E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1E0839052D5E0DAC00E2FA3E = {
+			isa = PBXGroup;
+			children = (
+				1E0839102D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection */,
+				1E08390F2D5E0DAC00E2FA3E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1E08390F2D5E0DAC00E2FA3E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1E08390E2D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1E0839102D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection */ = {
+			isa = PBXGroup;
+			children = (
+				1E0839112D5E0DAC00E2FA3E /* Milestone13_15_PhotoCollectionApp.swift */,
+				1E0839132D5E0DAC00E2FA3E /* ContentView.swift */,
+				1E0839272D5E81EE00E2FA3E /* ContentView-ViewModel.swift */,
+				1E0839252D5E7D6900E2FA3E /* DetailView.swift */,
+				1E08391F2D5E419A00E2FA3E /* AddImageView.swift */,
+				1E0839232D5E4F2400E2FA3E /* Item.swift */,
+				1E0839152D5E0DB300E2FA3E /* Assets.xcassets */,
+				1E0839172D5E0DB300E2FA3E /* Preview Content */,
+			);
+			path = "Milestone13-15_PhotoCollection";
+			sourceTree = "<group>";
+		};
+		1E0839172D5E0DB300E2FA3E /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				1E0839182D5E0DB300E2FA3E /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1E08390D2D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1E08391C2D5E0DB300E2FA3E /* Build configuration list for PBXNativeTarget "Milestone13-15_PhotoCollection" */;
+			buildPhases = (
+				1E08390A2D5E0DAC00E2FA3E /* Sources */,
+				1E08390B2D5E0DAC00E2FA3E /* Frameworks */,
+				1E08390C2D5E0DAC00E2FA3E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Milestone13-15_PhotoCollection";
+			productName = "Milestone13-15_PhotoCollection";
+			productReference = 1E08390E2D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1E0839062D5E0DAC00E2FA3E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1520;
+				LastUpgradeCheck = 1520;
+				TargetAttributes = {
+					1E08390D2D5E0DAC00E2FA3E = {
+						CreatedOnToolsVersion = 15.2;
+					};
+				};
+			};
+			buildConfigurationList = 1E0839092D5E0DAC00E2FA3E /* Build configuration list for PBXProject "Milestone13-15_PhotoCollection" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1E0839052D5E0DAC00E2FA3E;
+			productRefGroup = 1E08390F2D5E0DAC00E2FA3E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1E08390D2D5E0DAC00E2FA3E /* Milestone13-15_PhotoCollection */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1E08390C2D5E0DAC00E2FA3E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1E0839192D5E0DB300E2FA3E /* Preview Assets.xcassets in Resources */,
+				1E0839162D5E0DB300E2FA3E /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1E08390A2D5E0DAC00E2FA3E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1E0839242D5E4F2400E2FA3E /* Item.swift in Sources */,
+				1E0839282D5E81EE00E2FA3E /* ContentView-ViewModel.swift in Sources */,
+				1E0839202D5E419A00E2FA3E /* AddImageView.swift in Sources */,
+				1E0839142D5E0DAC00E2FA3E /* ContentView.swift in Sources */,
+				1E0839262D5E7D6900E2FA3E /* DetailView.swift in Sources */,
+				1E0839122D5E0DAC00E2FA3E /* Milestone13_15_PhotoCollectionApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1E08391A2D5E0DB300E2FA3E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1E08391B2D5E0DB300E2FA3E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1E08391D2D5E0DB300E2FA3E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Milestone13-15_PhotoCollection/Preview Content\"";
+				DEVELOPMENT_TEAM = JG8KZK844U;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.studyduude.Milestone13-15-PhotoCollection";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1E08391E2D5E0DB300E2FA3E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Milestone13-15_PhotoCollection/Preview Content\"";
+				DEVELOPMENT_TEAM = JG8KZK844U;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.studyduude.Milestone13-15-PhotoCollection";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1E0839092D5E0DAC00E2FA3E /* Build configuration list for PBXProject "Milestone13-15_PhotoCollection" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1E08391A2D5E0DB300E2FA3E /* Debug */,
+				1E08391B2D5E0DB300E2FA3E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1E08391C2D5E0DB300E2FA3E /* Build configuration list for PBXNativeTarget "Milestone13-15_PhotoCollection" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1E08391D2D5E0DB300E2FA3E /* Debug */,
+				1E08391E2D5E0DB300E2FA3E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1E0839062D5E0DAC00E2FA3E /* Project object */;
+}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/AddImageView.swift
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/AddImageView.swift
@@ -1,0 +1,71 @@
+//
+//  AddImageView.swift
+//  Milestone13-15_PhotoCollection
+//
+//  Created by HUA Cindy on 13/02/2025.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct AddImageView: View {
+    @Environment(\.dismiss) var dismiss
+    @Binding var viewModel: ViewModel
+    
+    @State private var pickerItem: PhotosPickerItem?
+    @State private var selectedImage: Image?
+    @State private var name: String = ""
+    @State private var imageData: Data = Data()
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                PhotosPicker(selection: $pickerItem) {
+                    if let selectedImage = selectedImage {
+                        selectedImage
+                            .resizable()
+                            .scaledToFit()
+                            .padding()
+                    } else {
+                        ContentUnavailableView("No picture", systemImage: "photo.badge.plus", description: Text("Tap to import a photo"))
+                            .frame(width: 300, height: 300)
+                    }
+                }
+                .buttonStyle(.plain)
+                .onChange(of: pickerItem, loadImage)
+                
+                TextField("Name", text: $name)
+                    .padding()
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+            .navigationTitle("Add new image")
+            .toolbar {
+                Button("Save") {
+                    viewModel.addImage(imageData: imageData, name: name)
+                    dismiss()
+                }
+            }
+        }
+    }
+    
+    func loadImage() {
+        Task {
+            if let pickerItem = pickerItem {
+                do {
+                    if let data = try await pickerItem.loadTransferable(type: Data.self) {
+                        if let uiImage = UIImage(data: data) {
+                            selectedImage = Image(uiImage: uiImage)
+                            imageData = data
+                        }
+                    }
+                } catch {
+                    print("Failed to load image: \(error)")
+                }
+            }
+        }
+    }
+}
+
+//#Preview {
+//    AddImageView()
+//}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Assets.xcassets/Contents.json
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/ContentView-ViewModel.swift
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/ContentView-ViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  ContentView-ViewModel.swift
+//  Milestone13-15_PhotoCollection
+//
+//  Created by HUA Cindy on 13/02/2025.
+//
+
+import Foundation
+
+@Observable
+class ViewModel {
+    var items: [Item]
+    let savePath = URL.documentsDirectory.appending(path: "SavedItems")
+    
+    init() {
+        do {
+            let data = try Data(contentsOf: savePath)
+            items = try JSONDecoder().decode([Item].self, from: data)
+        } catch {
+            items = []
+        }
+    }
+    
+    func save() {
+        do {
+            let data = try JSONEncoder().encode(items)
+            try data.write(to: savePath, options: [.atomic, .completeFileProtection])
+            print("Data saved successfully to \(savePath)")
+        } catch {
+            print("Failed to save data: \(error.localizedDescription)")
+        }
+    }
+    
+    func addImage(imageData: Data, name: String) {
+        items.append(Item(imageData: imageData, name: name))
+        save()
+    }
+    
+    
+    
+}
+

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/ContentView.swift
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/ContentView.swift
@@ -1,0 +1,45 @@
+//
+//  ContentView.swift
+//  Milestone13-15_PhotoCollection
+//
+//  Created by HUA Cindy on 13/02/2025.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State private var viewModel = ViewModel()
+    @State private var showingAddImage = false
+    
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(viewModel.items.sorted(), id: \.id) { item in
+                    NavigationLink(destination: DetailView(item: item)) {
+                        HStack {
+                            item.image
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                                .scaledToFit()
+                            Text(item.name)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Photo Collection")
+            .toolbar {
+                Button {showingAddImage.toggle()
+                } label: {
+                    Label("Add image", systemImage: "plus")
+                }
+            }
+            .sheet(isPresented: $showingAddImage, content: {
+                AddImageView(viewModel: $viewModel)
+            })
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/DetailView.swift
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/DetailView.swift
@@ -1,0 +1,29 @@
+//
+//  DetailView.swift
+//  Milestone13-15_PhotoCollection
+//
+//  Created by HUA Cindy on 13/02/2025.
+//
+
+import SwiftUI
+
+struct DetailView: View {
+    var item: Item
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Text(item.name)
+                    .font(.title)
+                item.image
+                    .resizable()
+                    .scaledToFit()
+                    .padding()
+            }
+        }
+    }
+}
+
+//#Preview {
+//    DetailView()
+//}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Item.swift
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Item.swift
@@ -1,0 +1,29 @@
+//
+//  Item.swift
+//  Milestone13-15_PhotoCollection
+//
+//  Created by HUA Cindy on 13/02/2025.
+//
+
+import Foundation
+import SwiftUI
+
+struct Item: Identifiable, Comparable, Codable {
+    var id = UUID()
+    var imageData: Data
+    var name: String
+    
+    var image: Image {
+        if let uiImage = UIImage(data: imageData) {
+            return Image(uiImage: uiImage)
+        } else {
+            return Image(systemName: "photo")
+        }
+    }
+    
+    static func <(lhs: Item, rhs: Item) -> Bool {
+        lhs.name < rhs.name
+    }
+}
+
+

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Milestone13_15_PhotoCollectionApp.swift
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Milestone13_15_PhotoCollectionApp.swift
@@ -1,0 +1,17 @@
+//
+//  Milestone13_15_PhotoCollectionApp.swift
+//  Milestone13-15_PhotoCollection
+//
+//  Created by HUA Cindy on 13/02/2025.
+//
+
+import SwiftUI
+
+@main
+struct Milestone13_15_PhotoCollectionApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/100DaysOfSwiftUI/Milestone13-15_PhotoCollection/Milestone13-15_PhotoCollection/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
closes #23 
Use PhotosPicker to let users import a photo from their photo library.
Detect when a new photo is imported, and immediately ask the user to name the photo.
Save that name and photo somewhere safe.
Show all names and photos in a list, sorted by name.
Create a detail screen that shows a picture full size.

![Milestone13-15_PhotoCollection](https://github.com/user-attachments/assets/991b1c4e-54ac-4fb4-8fdf-10938363f435)
